### PR TITLE
removed CI flag for code warnings

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -9,6 +9,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      CI: false
     steps:
         - uses: actions/checkout@v2
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -9,6 +9,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      CI: false
     steps:
         - uses: actions/checkout@v2
 


### PR DESCRIPTION
defaults to true?
Treating warnings as errors because process.env.CI = true.
Most CI servers set it automatically.

https://github.community/t/treating-warnings-as-errors-because-process-env-ci-true/18032/7